### PR TITLE
[SRE-16197] add validate option to docker-gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,48 +84,53 @@ Generate files from docker container meta-data
 
 Options:
   -config value
-      config files with template directives. Config files will be merged if this option is specified multiple times. (default [])
+        config files with template directives. Config files will be merged if this option is specified multiple times.
   -endpoint string
-      docker api endpoint (tcp|unix://..). Default unix:///var/run/docker.sock
-  -interval int
-      notify command interval (secs)
-  -keep-blank-lines
-      keep blank lines in the output file
-  -notify restart xyz
-      run command after template is regenerated (e.g restart xyz)
-  -notify-output
-      log the output(stdout/stderr) of notify command
-  -notify-sighup container-ID
-      send HUP signal to container.  Equivalent to 'docker kill -s HUP container-ID'
-  -only-exposed
-      only include containers with exposed ports
-  -only-published
-      only include containers with published ports (implies -only-exposed)
+        docker api endpoint (tcp|unix://..). Default unix:///var/run/docker.sock
   -include-stopped
-      include stopped containers
+        include stopped containers
+  -interval int
+        notify command interval (secs)
+  -keep-blank-lines
+        keep blank lines in the output file
+  -notify restart xyz
+        run command after template is regenerated (e.g restart xyz)
+  -notify-output
+        log the output(stdout/stderr) of notify command
+  -notify-sighup container-ID
+        send HUP signal to container.  Equivalent to docker kill -s HUP container-ID
+  -only-exposed
+        only include containers with exposed ports
+  -only-published
+        only include containers with published ports (implies -only-exposed)
   -tlscacert string
-      path to TLS CA certificate file (default "/Users/jason/.docker/machine/machines/default/ca.pem")
+        path to TLS CA certificate file (default "/Users/john.knutson/.docker/ca.pem")
   -tlscert string
-      path to TLS client certificate file (default "/Users/jason/.docker/machine/machines/default/cert.pem")
+        path to TLS client certificate file (default "/Users/john.knutson/.docker/cert.pem")
   -tlskey string
-      path to TLS client key file (default "/Users/jason/.docker/machine/machines/default/key.pem")
+        path to TLS client key file (default "/Users/john.knutson/.docker/key.pem")
   -tlsverify
-      verify docker daemon's TLS certicate (default true)
+        verify docker daemon's TLS certicate
+  -validate
+        verify config file(s)
   -version
-      show version
+        show version
+  -wait string
+        minimum and maximum durations to wait (e.g. "500ms:2s") before triggering generate
   -watch
-      watch for container changes
-  -wait
-      minimum (and/or maximum) duration to wait after each container change before triggering
+        watch for container changes
 
 Arguments:
   template - path to a template to generate
-  dest - path to a write the template. If not specfied, STDOUT is used
+  dest - path to a write the template.  If not specfied, STDOUT is used
 
 Environment Variables:
   DOCKER_HOST - default value for -endpoint
-  DOCKER_CERT_PATH - directory path containing key.pem, cert.pm and ca.pem
-  DOCKER_TLS_VERIFY - enable client TLS verification]
+  DOCKER_CERT_PATH - directory path containing key.pem, cert.pem and ca.pem
+  DOCKER_TLS_VERIFY - enable client TLS verification
+  DOCKER_VALIDATE - validate config file(s)
+
+For more information, see https://github.com/jwilder/docker-gen
 ```
 
 If no `<dest>` file is specified, the output is sent to stdout. Mainly useful for debugging.

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -20,6 +20,7 @@ var (
 	version                 bool
 	watch                   bool
 	wait                    string
+	validate                bool
 	notifyCmd               string
 	notifyOutput            bool
 	notifySigHUPContainerID string
@@ -89,6 +90,7 @@ func initFlags() {
 	flag.BoolVar(&watch, "watch", false, "watch for container changes")
 	flag.StringVar(&wait, "wait", "", "minimum and maximum durations to wait (e.g. \"500ms:2s\") before triggering generate")
 	flag.BoolVar(&onlyExposed, "only-exposed", false, "only include containers with exposed ports")
+	flag.BoolVar(&validate, "validate", os.Getenv("DOCKER_VALIDATE") != "", "verify config file(s)")
 
 	flag.BoolVar(&onlyPublished, "only-published", false,
 		"only include containers with published ports (implies -only-exposed)")
@@ -129,6 +131,10 @@ func main() {
 			if err != nil {
 				log.Fatalf("Error loading config %s: %s\n", configFile, err)
 			}
+		}
+		if validate == true {
+			log.Print("Config file(s) parsed successfully")
+			os.Exit(0)
 		}
 	} else {
 		w, err := dockergen.ParseWait(wait)

--- a/cmd/docker-gen/main.go
+++ b/cmd/docker-gen/main.go
@@ -90,7 +90,7 @@ func initFlags() {
 	flag.BoolVar(&watch, "watch", false, "watch for container changes")
 	flag.StringVar(&wait, "wait", "", "minimum and maximum durations to wait (e.g. \"500ms:2s\") before triggering generate")
 	flag.BoolVar(&onlyExposed, "only-exposed", false, "only include containers with exposed ports")
-	flag.BoolVar(&validate, "validate", os.Getenv("DOCKER_VALIDATE") != "", "verify config file(s)")
+	flag.BoolVar(&validate, "validate", os.Getenv("DOCKER_VALIDATE") != "", "validate config file(s)")
 
 	flag.BoolVar(&onlyPublished, "only-published", false,
 		"only include containers with published ports (implies -only-exposed)")

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Dest             string
 	Watch            bool
 	Wait             *Wait
+	Validate         bool
 	NotifyCmd        string
 	NotifyOutput     bool
 	NotifyContainers map[string]docker.Signal


### PR DESCRIPTION
adds ` -validate` option that short circuits the program after checking configs if passed

running w/docker:
```
$ docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v $PWD/examples:/examples docker-gen:latest -validate -config /examples/docker-gen.cfg
```

valid file example:
```
$ ./docker-gen -validate -config examples/docker-gen.cfg
2020/09/21 14:41:10 Config file(s) parsed successfully
```
invalid file example:
```
$ ./docker-gen -validate -config examples/docker-gen-invalid.cfg
2020/09/21 14:41:14 Error loading config examples/docker-gen-invalid.cfg: Near line 0 (last key parsed ''): Bare keys cannot contain '\n'.
```